### PR TITLE
Do not require SDK as a runtime

### DIFF
--- a/io.github.JakubMelka.Pdf4qt.json
+++ b/io.github.JakubMelka.Pdf4qt.json
@@ -1,6 +1,6 @@
 {
     "app-id": "io.github.JakubMelka.Pdf4qt",
-    "runtime": "org.kde.Sdk",
+    "runtime": "org.kde.Platform",
     "runtime-version": "6.9",
     "sdk": "org.kde.Sdk",
     "command": "Pdf4QtEditor",


### PR DESCRIPTION
Tested locally, and the application still works.

Fixes #12